### PR TITLE
Discard master/slave jargon

### DIFF
--- a/batterycheck_test.py
+++ b/batterycheck_test.py
@@ -67,7 +67,7 @@ def main():
     except KeyboardInterrupt:
         _log.info('Ctrl-C caught: complete.')
     except Exception as e:
-        _log.error('error closing master: {}'.format(e))
+        _log.error('error closing main: {}'.format(e))
     finally:
         sys.exit(0)
 

--- a/front_test.py
+++ b/front_test.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 by Murray Altheim. All rights reserved. This file is part
-# of the pimaster2ardslave project and is released under the MIT Licence;
+# of the pimain2ardsubordinate project and is released under the MIT Licence;
 # please see the LICENSE file included as part of this package.
 #
 # author:   Murray Altheim

--- a/i2c_slave_test.py
+++ b/i2c_slave_test.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 by Murray Altheim. All rights reserved. This file is part
-# of the pimaster2ardslave project and is released under the MIT Licence;
+# of the pimain2ardsubordinate project and is released under the MIT Licence;
 # please see the LICENSE file included as part of this package.
 #
 # author:   Murray Altheim
@@ -19,7 +19,7 @@
 #
 
 from lib.logger import Level
-from lib.i2c_master import I2cMaster
+from lib.i2c_main import I2cMain
 from lib.config_loader import ConfigLoader
 
 # ..............................................................................
@@ -33,12 +33,12 @@ def main():
         _config = _loader.configure(filename)
 
         _loop_count = 10000
-        _master = I2cMaster(_config, Level.INFO)
+        _main = I2cMain(_config, Level.INFO)
 
-        if _master is not None:
+        if _main is not None:
 
             # set it to some very large number if you want it to go on for a long time...
-            _master.test_configuration(_loop_count) # see documentation for hardware configuration
+            _main.test_configuration(_loop_count) # see documentation for hardware configuration
 
         else:
             raise Exception('unable to establish contact with Arduino on address 0x{:02X}'.format(_device_id))
@@ -46,8 +46,8 @@ def main():
     except KeyboardInterrupt:
         self._log.warning('Ctrl-C caught; exiting...')
     finally:
-        if _master:
-            _master.close()
+        if _main:
+            _main.close()
 
 
 if __name__== "__main__":

--- a/lib/front.py
+++ b/lib/front.py
@@ -14,7 +14,7 @@ from colorama import init, Fore, Style
 init()
 
 from lib.logger import Logger, Level
-from lib.i2c_master import I2cMaster
+from lib.i2c_main import I2cMain
 from lib.event import Event
 from lib.message import Message
 
@@ -22,7 +22,7 @@ from lib.message import Message
 class IntegratedFrontSensor():
     '''
         IntegratedFrontSensor: communicates with the integrated front bumpers 
-           and infrared sensors, receiving messages from the I2C Arduino slave,
+           and infrared sensors, receiving messages from the I2C Arduino subordinate,
            sending the messages with its events onto the message bus.
         
         Parameters:
@@ -49,7 +49,7 @@ class IntegratedFrontSensor():
         self._loop_delay_sec = self._config.get('loop_delay_sec')
         self._log.debug('initialising integrated front sensor...')
 
-        self._master = I2cMaster(config, Level.INFO)
+        self._main = I2cMain(config, Level.INFO)
         self._closed = False
         self._enabled = False
         self._log.info('ready.')
@@ -58,7 +58,7 @@ class IntegratedFrontSensor():
     # ..........................................................................
     def _callback_front(self, pin, pin_type, value):
         '''
-            This is the callback method from the I2C Master, whose events are
+            This is the callback method from the I2C Main, whose events are
             being returned from the Arduino.
 
             The pin designations for each sensor here mirror those in the YAML 
@@ -101,7 +101,7 @@ class IntegratedFrontSensor():
         if not self._closed:
             self._log.info('enabled integrated front sensor.')
             self._enabled = True
-            self._master.front_sensor_loop(self._queue, self._enabled, self._loop_delay_sec, self._callback_front)
+            self._main.front_sensor_loop(self._queue, self._enabled, self._loop_delay_sec, self._callback_front)
         else:
             self._log.warning('cannot enable integrated front sensor: already closed.')
 
@@ -110,8 +110,8 @@ class IntegratedFrontSensor():
     def disable(self):
         self._log.info('disabled integrated front sensor.')
         self._enabled = False
-        if self._master:
-            self._master.disable()
+        if self._main:
+            self._main.disable()
 
 
     # ..........................................................................

--- a/lib/i2c_master.py
+++ b/lib/i2c_master.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 by Murray Altheim. All rights reserved. This file is part
-# of the pimaster2ardslave project and is released under the MIT Licence;
+# of the pimain2ardsubordinate project and is released under the MIT Licence;
 # please see the LICENSE file included as part of this package.
 #
 # author:   Murray Altheim
@@ -30,12 +30,12 @@ CLEAR_SCREEN = '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n
 #CLEAR_SCREEN = '\n'  # no clear screen
 
 # ..............................................................................
-class I2cMaster():
+class I2cMain():
     '''
-        A Raspberry Pi Master for a corresponding Arduino Slave.
+        A Raspberry Pi Main for a corresponding Arduino Subordinate.
 
         Parameters:
-          device_id:  the I²C address over which the master and slave communicate
+          device_id:  the I²C address over which the main and subordinate communicate
           level:      the log level, e.g., Level.INFO
     '''
 
@@ -43,11 +43,11 @@ class I2cMaster():
         super().__init__()
         if config is None:
             raise ValueError('no configuration provided.')
-        self._config = config['ros'].get('i2c_master')
-        self._device_id  = self._config.get('device_id') # i2c hex address of slave device, must match Arduino's SLAVE_I2C_ADDRESS
+        self._config = config['ros'].get('i2c_main')
+        self._device_id  = self._config.get('device_id') # i2c hex address of subordinate device, must match Arduino's SLAVE_I2C_ADDRESS
         self._channel = self._config.get('channel')
 
-        self._log = Logger('i²cmaster-0x{:02x}'.format(self._device_id), level)
+        self._log = Logger('i²cmain-0x{:02x}'.format(self._device_id), level)
         self._log.info('initialising...')
         self._counter = itertools.count()
         self._loop_count = 0  # currently only used in testing
@@ -215,16 +215,16 @@ class I2cMaster():
         '''
             Close the instance.
         '''
-        self._log.debug('closing I²C master.')
+        self._log.debug('closing I²C main.')
         if not self._closed:
             try:
                 self._closed = True
 #               self._pi.i2c_close(self._handle) # close device
-                self._log.debug('I²C master closed.')
+                self._log.debug('I²C main closed.')
             except Exception as e:
-                self._log.error('error closing master: {}'.format(e))
+                self._log.error('error closing main: {}'.format(e))
         else:
-            self._log.debug('I²C master already closed.')
+            self._log.debug('I²C main already closed.')
 
 
     # ..........................................................................
@@ -287,7 +287,7 @@ class I2cMaster():
         except KeyboardInterrupt:
             self._log.warning('Ctrl-C caught; exiting...')
         except Exception as e:
-            self._log.error('error in master: {}'.format(e))
+            self._log.error('error in main: {}'.format(e))
             traceback.print_exc(file=sys.stdout)
 #       finally:
 #           self.close()
@@ -300,8 +300,8 @@ class I2cMaster():
     # ..........................................................................
     def test_echo(self):
         '''
-            Performs a simple test, sending a series of bytes to the slave, then
-            reading the return values. The Arduino slave's 'isEchoTest' boolean
+            Performs a simple test, sending a series of bytes to the subordinate, then
+            reading the return values. The Arduino subordinate's 'isEchoTest' boolean
             must be set to true. This does not require any hardware configuration
             save that the Raspberry Pi must be connected to the Arduino via I²C
             and that there is no contention on address 0x08.
@@ -365,7 +365,7 @@ class I2cMaster():
         except KeyboardInterrupt:
             self._log.warning('Ctrl-C caught; exiting...')
         except Exception as e:
-            self._log.error('error in master: {}'.format(e))
+            self._log.error('error in main: {}'.format(e))
             traceback.print_exc(file=sys.stdout)
 
 
@@ -439,7 +439,7 @@ class I2cMaster():
         except KeyboardInterrupt:
             self._log.warning('Ctrl-C caught; exiting...')
         except Exception as e:
-            self._log.error('error in master: {}'.format(e))
+            self._log.error('error in main: {}'.format(e))
             traceback.print_exc(file=sys.stdout)
 #       finally:
 #           self.close()

--- a/lib/pintype.py
+++ b/lib/pintype.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 by Murray Altheim. All rights reserved. This file is part
-# of the pimaster2ardslave project and is released under the MIT Licence;
+# of the pimain2ardsubordinate project and is released under the MIT Licence;
 # please see the LICENSE file included as part of this package.
 #
 # author:   Murray Altheim


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.